### PR TITLE
Report erroneous config values

### DIFF
--- a/src/flake8/options/config.py
+++ b/src/flake8/options/config.py
@@ -207,11 +207,15 @@ class MergedConfigParser(object):
 
             # Use the appropriate method to parse the config value
             method = config_parser.get
-            if (option.type in self.GETINT_TYPES or
-                    option.action in self.GETINT_TYPES):
-                method = config_parser.getint
-            elif option.action in self.GETBOOL_ACTIONS:
-                method = config_parser.getboolean
+            try:
+                if (option.type in self.GETINT_TYPES or
+                        option.action in self.GETINT_TYPES):
+                    method = config_parser.getint
+                elif option.action in self.GETBOOL_ACTIONS:
+                    method = config_parser.getboolean
+            except ValueError:
+                raise ValueError('Unable to parse value ("%s") of option "%s',
+                        option, option_name)
 
             value = method(self.program_name, option_name)
             LOG.debug('Option "%s" returned value: %r', option_name, value)


### PR DESCRIPTION
Hi!

Just recently stumbled upon this use-case myself. I'd putten `Verbose = True` in my `setup.cfg` under the `[flake8]` section.
This stacktrace ain't all that helpful for those who don't mind digging into other's code, so I hope my PR might be of aid/inspiration to help ease the user's experience =)
```
> python -m pipenv run python -m flake8 overtime_calculator
C:\Users\x10an14\.virtualenvs\overtime-calculator-voKtduX3\lib\site-packages\pycodestyle.py:113: FutureWarning: Possible nested set at position 1
  EXTRANEOUS_WHITESPACE_REGEX = re.compile(r'[[({] | []}),;:]')
Traceback (most recent call last):
  File "C:\Program Files\Python37\Lib\runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "C:\Program Files\Python37\Lib\runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "C:\Users\x10an14\.virtualenvs\overtime-calculator-voKtduX3\lib\site-packages\flake8\__main__.py", line 4, in <module>
    cli.main()
  File "C:\Users\x10an14\.virtualenvs\overtime-calculator-voKtduX3\lib\site-packages\flake8\main\cli.py", line 16, in main
    app.run(argv)
  File "C:\Users\x10an14\.virtualenvs\overtime-calculator-voKtduX3\lib\site-packages\flake8\main\application.py", line 396, in run
    self._run(argv)
  File "C:\Users\x10an14\.virtualenvs\overtime-calculator-voKtduX3\lib\site-packages\flake8\main\application.py", line 383, in _run
    self.initialize(argv)
  File "C:\Users\x10an14\.virtualenvs\overtime-calculator-voKtduX3\lib\site-packages\flake8\main\application.py", line 367, in initialize
    self.parse_configuration_and_cli(argv)
  File "C:\Users\x10an14\.virtualenvs\overtime-calculator-voKtduX3\lib\site-packages\flake8\main\application.py", line 212, in parse_configuration_and_cli
    self.option_manager, self.config_finder, argv
  File "C:\Users\x10an14\.virtualenvs\overtime-calculator-voKtduX3\lib\site-packages\flake8\options\aggregator.py", line 46, in aggregate_options
    original_values.isolated)
  File "C:\Users\x10an14\.virtualenvs\overtime-calculator-voKtduX3\lib\site-packages\flake8\options\config.py", line 297, in parse
    return self.merge_user_and_local_config()
  File "C:\Users\x10an14\.virtualenvs\overtime-calculator-voKtduX3\lib\site-packages\flake8\options\config.py", line 261, in merge_user_and_local_config
    config = self.parse_local_config()
  File "C:\Users\x10an14\.virtualenvs\overtime-calculator-voKtduX3\lib\site-packages\flake8\options\config.py", line 228, in parse_local_config
    return self._parse_config(config)
  File "C:\Users\x10an14\.virtualenvs\overtime-calculator-voKtduX3\lib\site-packages\flake8\options\config.py", line 207, in _parse_config
    value = method(self.program_name, option_name)
  File "C:\Program Files\Python37\Lib\configparser.py", line 818, in getint
    fallback=fallback, **kwargs)
  File "C:\Program Files\Python37\Lib\configparser.py", line 808, in _get_conv
    **kwargs)
  File "C:\Program Files\Python37\Lib\configparser.py", line 802, in _get
    return conv(self.get(section, option, **kwargs))
ValueError: invalid literal for int() with base 10: 'True'
```